### PR TITLE
(fix): Client_secret class attribute definition

### DIFF
--- a/src/class/GoogleVision.php
+++ b/src/class/GoogleVision.php
@@ -10,6 +10,7 @@ class CFGoogle
     var $error = false;
     var $errorMsg = [];
     var $client;
+    var $client_secret;
     var $scope;
     var $type = 'installed';
 


### PR DESCRIPTION
Definition attribute of the client_secret class because the version of PHP used does not allow dynamic generation.