### PR TITLE
(fix) Deprecated strlen(null) en línea 4450

### DIFF
--- a/src/Core7.php
+++ b/src/Core7.php
@@ -4447,7 +4447,7 @@ if (!defined("_CLOUDFRAMEWORK_CORE_CLASSES_")) {
 
                 $this->http = $this->core->config->get("CloudServiceUrl");
 
-                if (strlen($path) && $path[0] != '/')
+                if (strlen($path ?? '') && ($path[0] ?? '') != '/')
                     $path = '/' . $path;
                 return ($this->http . $path);
             }


### PR DESCRIPTION
Problem:
A "deprecated strlen(null)" error was detected on line 4450 due to attempting to get the length of a potentially null value without prior validation.

Solution:
- Added validation to check for value existence before applying strlen()
- Implemented explicit string transformation when value exists

Impact:
- Removes deprecated strlen(null) warning
- Prevents potential null value errors
- Improves code robustness

Testing:
- Verified with null values
- Verified with valid values
- No side effects on other functionalities
