### PR TITLE
[FIX] Skip null filters in DataSQL WHERE clause builder

### DIFF
--- a/src/class/DataSQL.php
+++ b/src/class/DataSQL.php
@@ -809,6 +809,10 @@ class DataSQL
                     $where.="{$this->entity_name}.{$key} != ''";
                     break;
                 default:
+
+                    // skip null filters — no añade condición al WHERE                                                                                                            
+                    if($value === null) continue 2;  
+
                     // IN
                     if(is_array($value)) {
                         if($this->fields[$key]=='int') {


### PR DESCRIPTION
## Summary

Add null guard in the `default` case of the switch block that processes WHERE conditions in `DataSQL::fetch()`. When a filter value is explicitly `null`, the new check skips adding any SQL condition for that key, preventing unintended WHERE clauses.

## Changes

`src/class/DataSQL.php`
- Lines ~799: Add `if($value === null) continue 2;` inside the `default` case of the switch, before the IN/equality logic

## Why `continue 2`

Inside a `switch` nested in a `foreach`, PHP counts `switch` as a loop level:
- `continue 1` → exits the switch (equivalent to `break`)
- `continue 2` → skips to the next `foreach` iteration ✓

## Test plan

- [ ] Verify queries with `null` values in `$keysWhere` do not generate any WHERE condition for those keys
- [ ] Verify existing filter logic (IN, `=`, `>=`, `<=`, `__null__`, `__notnull__`, etc.) still works correctly
- [ ] Run PHP lint: `php -l src/class/DataSQL.php`