### PR TITLE
fix: Enable SSL/TLS verification in Firebase client (CRIT-02 ISO27001)

### DIFF
--- a/src/class/Firebase.php
+++ b/src/class/Firebase.php
@@ -207,7 +207,8 @@ if (!defined ("_Google_CLASS_") ) {
             curl_setopt($ch, CURLOPT_URL, $url);
             curl_setopt($ch, CURLOPT_TIMEOUT, $this->_timeout);
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->_timeout);
-            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $mode);
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);


### PR DESCRIPTION
## Summary
- Enables SSL peer verification (`CURLOPT_SSL_VERIFYPEER = true`) in Firebase HTTP client
- Adds host verification (`CURLOPT_SSL_VERIFYHOST = 2`)
- Previously disabled SSL verification allowed MITM attacks

## ISO 27001
- A.10.1.1 - Cryptographic controls policy
- A.13.1.1 - Network controls
- A.13.2.1 - Information transfer policies

## OWASP
- A02:2021 - Cryptographic Failures

## Test plan
- [ ] Verify Firebase authentication still works in development
- [ ] Verify Firebase calls succeed with valid SSL certificates
- [ ] Confirm no regression in Firebase-dependent features

🤖 Generated with [Claude Code](https://claude.com/claude-code)