### PR TITLE
fix: Default deny access when no security configured in dbproxy (HIGH-08 ISO27001)

### DIFF
--- a/src/api/_dbproxy.php
+++ b/src/api/_dbproxy.php
@@ -131,8 +131,8 @@ class API extends RESTful
             $this->returnData['app_security'] = $security;
         //endregion
 
-        //if there is no security then any user can access. Then just return true;
-        if (!$security) return true;
+        // Sin seguridad configurada = acceso denegado por defecto (principio de mínimo privilegio)
+        if (!$security) return ($sendAPIError) ? $this->setErrorFromCodelib('not-allowed', 'No security configuration found. Access denied by default (fail-closed policy)') : false;
 
         //check spacenames security
         if (isset($security['spacenames']) && is_array($security['spacenames']) && $security['spacenames']) {
@@ -192,6 +192,13 @@ class API extends RESTful
 
         if ($sec_error) {
             if ($sendAPIError) return ($this->setErrorFromCodelib('not-allowed', 'Your privileges does not match with ' . $sec_error . ' privilege app: ' . json_encode($security)));
+            else return false;
+        }
+
+        // Si no se evaluó ninguna regla de seguridad (security config vacía o sin reglas conocidas), denegar acceso
+        $has_rules = isset($security['spacenames']) || isset($security['user_spacenames']) || isset($security['user_privileges']) || isset($security['user_organizations']);
+        if (!$has_rules) {
+            if ($sendAPIError) return ($this->setErrorFromCodelib('not-allowed', 'Security configuration has no valid rules. Access denied by default (fail-closed policy)'));
             else return false;
         }
 


### PR DESCRIPTION
## Summary
- Changed fail-open behavior to fail-closed in `_dbproxy.php`
- When no security configuration is present, access is now denied (returns `false`) instead of granted (was `true`)
- Enforces principle of least privilege: explicit allow rather than implicit allow

## ISO 27001
- A.9.4.1 - Information access restriction
- A.14.1.2 - Securing application services on public networks

## OWASP
- A01:2021 - Broken Access Control

## Test plan
- [ ] Verify that requests with valid security config still succeed
- [ ] Verify that requests without security config are now rejected with 403
- [ ] Check that existing integrations have proper security configuration

## ⚠️ Breaking Change
Installations using `_dbproxy` without security configuration will now receive access denied. Security config must be explicitly defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)