### PR TITLE
[HOTFIX] Fix null $html passed to utf8Encode in WorkFlows

### DIFF
--- a/src/class/WorkFlows.php
+++ b/src/class/WorkFlows.php
@@ -541,7 +541,7 @@ class WorkFlows
                             "Tags" => $tags,
                             "Opens" => 0,
                             "Clicks" => 0,
-                            "BODY_HTML" => $this->core->utf8Encode($html),
+                            "BODY_HTML" => $this->core->utf8Encode($html ?? ''),
                             "DateProcessing" => "now",
                             "UpdateProcessing" => "now",
                             "StatusProcessing" => $item['status'] ?? 'unknown',


### PR DESCRIPTION
## Summary
- `$html` can be `null` in `WorkFlows.php:544` when sending emails without an explicit HTML body (no `params['html']` and no template slug)
- `utf8Encode()` has a strict `string` type declaration, causing a `TypeError` at runtime
- Fix: add `?? ''` null coalescing operator before passing to `utf8Encode`

## File changed
- `src/class/WorkFlows.php` — line 544 only

## Related
- Previous HOTFIX `3f6003a` fixed the same issue in `getEntityFromMandrillMessage()` (lines 829-830) for inbound Mandrill webhooks
- This fix covers the **outbound** email send path